### PR TITLE
Fix analytics transactions #54

### DIFF
--- a/phenoback/utils/data.py
+++ b/phenoback/utils/data.py
@@ -77,6 +77,14 @@ def get_observation(observation_id: str) -> dict:
     return get_document("observations", observation_id)
 
 
+def update_observation(observation_id: str, data: dict) -> None:
+    update_document("observations", observation_id, data)
+
+
+def delete_observation(observation_id: str) -> None:
+    delete_document("observations", observation_id)
+
+
 def write_observation(observation_id: str, data: dict) -> None:
     write_document("observations", observation_id, data)
 

--- a/phenoback/utils/firestore.py
+++ b/phenoback/utils/firestore.py
@@ -25,6 +25,10 @@ def firestore_client() -> Client:
     return _db
 
 
+def get_transaction():
+    return firestore_client().transaction()
+
+
 def delete_document(collection: str, document_id: str) -> None:
     log.debug("Delete document %s from %s", document_id, collection)
     firestore_client().collection(collection).document(document_id).delete()

--- a/test/test_analytics.py
+++ b/test/test_analytics.py
@@ -47,9 +47,7 @@ def get_state_doc(
     return result
 
 
-def add_state(
-    state_doc: dict, phase: str, observation_id: str, date: datetime
-) -> dict:
+def add_state(state_doc: dict, phase: str, observation_id: str, date: datetime) -> dict:
     state_doc["state"].setdefault(phase, {})[observation_id] = date
     return state_doc
 
@@ -191,9 +189,7 @@ def test_update_state_write(state_doc, obs_id, obs_date, phase, expected):
         (("id1", "phase1"), ("id1", "phase2"), 1),
     ],
 )
-def test_update_state_returned_states(
-    state_doc, initial_state, next_state, expected
-):
+def test_update_state_returned_states(state_doc, initial_state, next_state, expected):
     initial_id = initial_state[0]
     initial_phase = initial_state[1]
     next_id = next_state[0]

--- a/test/test_analytics.py
+++ b/test/test_analytics.py
@@ -18,13 +18,13 @@ def _date(i: int) -> datetime:
     return datetime(i, i, i, i, tzinfo=timezone.utc)
 
 
-observation_id = "id"
-source = "src"
-species = "species"
-phase = "phase"
-year = 2000
-altitude_grp = "grp"
-date = _date(1)
+OBSERVATION_ID = "id"
+SOURCE = "src"
+SPECIES = "species"
+PHASE = "phase"
+YEAR = 2000
+ALTITUDE_GRP = "grp"
+DATE = _date(1)
 
 
 def _data(write_document_mock: Mock) -> dict:
@@ -35,11 +35,11 @@ def _data(write_document_mock: Mock) -> dict:
     return write_document_mock.call_args[0][2]
 
 
-def _get_base_state_doc(
-    source: str = source,
-    species: str = species,
-    year: int = year,
-    altitude_grp: str = altitude_grp,
+def get_state_doc(
+    source: str = SOURCE,
+    species: str = SPECIES,
+    year: int = YEAR,
+    altitude_grp: str = ALTITUDE_GRP,
 ) -> dict:
     result = {"source": source, "species": species, "year": year, "state": {}}
     if altitude_grp:
@@ -47,7 +47,7 @@ def _get_base_state_doc(
     return result
 
 
-def _add_observation_to_state_doc(
+def add_state(
     state_doc: dict, phase: str, observation_id: str, date: datetime
 ) -> dict:
     state_doc["state"].setdefault(phase, {})[observation_id] = date
@@ -55,8 +55,8 @@ def _add_observation_to_state_doc(
 
 
 @pytest.fixture()
-def base_state_doc():
-    return _get_base_state_doc()
+def state_doc():
+    return get_state_doc()
 
 
 @contextmanager
@@ -67,7 +67,7 @@ def transaction():
 
 
 def read_state(
-    year=year, species=species, source=source, altitude_grp=altitude_grp
+    year=YEAR, species=SPECIES, source=SOURCE, altitude_grp=ALTITUDE_GRP
 ) -> dict:
     return get_document(
         analytics.STATE_COLLECTION,
@@ -76,7 +76,7 @@ def read_state(
 
 
 def read_result(
-    year=year, species=species, source=source, altitude_grp=altitude_grp
+    year=YEAR, species=SPECIES, source=SOURCE, altitude_grp=ALTITUDE_GRP
 ) -> dict:
     return get_document(
         analytics.RESULT_COLLECTION,
@@ -84,7 +84,7 @@ def read_result(
     )
 
 
-def write_state_doc(state_doc):
+def write_state(state_doc):
     write_document(
         analytics.STATE_COLLECTION,
         analytics.get_analytics_document_id(
@@ -102,21 +102,21 @@ def test_update_state_initalized(altitude_grp):
     transactional_update_state = transactional(analytics.update_state)
     with transaction() as t:
         result_state = transactional_update_state(
-            t, observation_id, date, phase, source, year, species, altitude_grp
+            t, OBSERVATION_ID, DATE, PHASE, SOURCE, YEAR, SPECIES, altitude_grp
         )
 
     # check written document
-    write_data = read_state(year, species, source, altitude_grp)
+    data = read_state(altitude_grp=altitude_grp)
     if altitude_grp is None:
-        assert "altitude_grp" not in write_data
+        assert "altitude_grp" not in data
     else:
-        assert write_data["altitude_grp"] == altitude_grp
-    assert write_data["source"] == source
-    assert write_data["year"] == year
-    assert write_data["species"] == species
-    assert write_data["state"]["phase"][observation_id].date() == date.date()
+        assert data["altitude_grp"] == altitude_grp
+    assert data["source"] == SOURCE
+    assert data["year"] == YEAR
+    assert data["species"] == SPECIES
+    assert data["state"]["phase"][OBSERVATION_ID] == DATE
     # check returned state
-    assert result_state[0] == date
+    assert result_state[0] == DATE
 
 
 @pytest.mark.parametrize(
@@ -139,22 +139,22 @@ def test_update_state_initalized(altitude_grp):
         ("id1", 1, "phase3", {"dictionary_item_added": ["root['state']['phase3']"]}),
     ],
 )
-def test_update_state_write(base_state_doc, obs_id, obs_date, phase, expected):
-    _add_observation_to_state_doc(base_state_doc, "phase1", "id1", _date(1))
-    _add_observation_to_state_doc(base_state_doc, "phase2", "id1", _date(2))
-    _add_observation_to_state_doc(base_state_doc, "phase1", "id2", _date(3))
-    _add_observation_to_state_doc(base_state_doc, "phase2", "id3", _date(4))
-    base_state_ref = copy.deepcopy(base_state_doc)
+def test_update_state_write(state_doc, obs_id, obs_date, phase, expected):
+    add_state(state_doc, "phase1", "id1", _date(1))
+    add_state(state_doc, "phase2", "id1", _date(2))
+    add_state(state_doc, "phase1", "id2", _date(3))
+    add_state(state_doc, "phase2", "id3", _date(4))
+    base_state_ref = copy.deepcopy(state_doc)
 
     write_document(
         analytics.STATE_COLLECTION,
         analytics.get_analytics_document_id(
-            base_state_doc["year"],
-            base_state_doc["species"],
-            base_state_doc["source"],
-            base_state_doc.get("altitude_grp"),
+            state_doc["year"],
+            state_doc["species"],
+            state_doc["source"],
+            state_doc.get("altitude_grp"),
         ),
-        base_state_doc,
+        state_doc,
     )
     transactional_update_state = transactional(analytics.update_state)
     with transaction() as t:
@@ -163,27 +163,27 @@ def test_update_state_write(base_state_doc, obs_id, obs_date, phase, expected):
             obs_id,
             _date(obs_date),
             phase,
-            base_state_doc["source"],
-            base_state_doc["year"],
-            base_state_doc["species"],
-            base_state_doc.get("altitude_grp"),
+            state_doc["source"],
+            state_doc["year"],
+            state_doc["species"],
+            state_doc.get("altitude_grp"),
         )
 
-    write_data = read_state(
-        base_state_doc["year"],
-        base_state_doc["species"],
-        base_state_doc["source"],
-        base_state_doc.get("altitude_grp"),
+    data = read_state(
+        state_doc["year"],
+        state_doc["species"],
+        state_doc["source"],
+        state_doc.get("altitude_grp"),
     )
 
-    assert deepdiff.DeepDiff(base_state_ref, write_data) == expected, (
+    assert deepdiff.DeepDiff(base_state_ref, data) == expected, (
         base_state_ref,
-        write_data,
+        data,
     )
 
 
 @pytest.mark.parametrize(
-    "initial_state, add_state, expected",
+    "initial_state, next_state, expected",
     [
         (("id1", "phase1"), ("id1", "phase1"), 1),
         (("id1", "phase1"), ("id2", "phase1"), 2),
@@ -192,30 +192,30 @@ def test_update_state_write(base_state_doc, obs_id, obs_date, phase, expected):
     ],
 )
 def test_update_state_returned_states(
-    base_state_doc, initial_state, add_state, expected
+    state_doc, initial_state, next_state, expected
 ):
     initial_id = initial_state[0]
     initial_phase = initial_state[1]
-    add_id = add_state[0]
-    add_phase = add_state[1]
-    _add_observation_to_state_doc(base_state_doc, initial_phase, initial_id, _date(1))
+    next_id = next_state[0]
+    next_phase = next_state[1]
+    add_state(state_doc, initial_phase, initial_id, DATE)
 
-    write_state_doc(base_state_doc)
+    write_state(state_doc)
 
     transactional_update_state = transactional(analytics.update_state)
     with transaction() as t:
         result_state = transactional_update_state(
             t,
-            add_id,
+            next_id,
             _date(2),
-            add_phase,
-            base_state_doc["source"],
-            base_state_doc["year"],
-            base_state_doc["species"],
-            base_state_doc.get("altitude_grp"),
+            next_phase,
+            state_doc["source"],
+            state_doc["year"],
+            state_doc["species"],
+            state_doc.get("altitude_grp"),
         )
 
-    assert len(result_state) == expected, (base_state_doc, result_state)
+    assert len(result_state) == expected, (state_doc, result_state)
     assert _date(2) in result_state
 
 
@@ -223,23 +223,23 @@ def test_update_results_no_dates():
     with transaction() as t:
         analytics.update_data(
             t,
-            observation_id,
+            OBSERVATION_ID,
             _date(2),
-            year,
-            species,
-            phase,
-            source,
-            altitude_grp,
+            YEAR,
+            SPECIES,
+            PHASE,
+            SOURCE,
+            ALTITUDE_GRP,
         )
 
     # check the phase is present
-    assert read_result()["values"][phase]
+    assert read_result()["values"][PHASE]
 
     with transaction() as t:
-        analytics.update_result(t, [], phase, source, year, species, altitude_grp)
+        analytics.update_result(t, [], PHASE, SOURCE, YEAR, SPECIES, ALTITUDE_GRP)
 
     # assert phase was deleted with the last value
-    assert not read_result()["values"].get(phase)
+    assert not read_result()["values"].get(PHASE)
 
 
 @pytest.mark.parametrize(
@@ -290,49 +290,49 @@ def test_update_results_calculation(state, e_min, e_max, e_median, e_q25, e_q75)
             t, state, phase, source, year, species, altitude_grp
         )
 
-    write_data = read_result()
+    data = read_result()
 
-    assert write_data["values"]["phase"]["min"] == e_min
-    assert write_data["values"]["phase"]["max"] == e_max
-    assert write_data["values"]["phase"]["median"] == e_median
-    assert write_data["values"]["phase"]["quantile_25"] == e_q25
-    assert write_data["values"]["phase"]["quantile_75"] == e_q75
+    assert data["values"]["phase"]["min"] == e_min
+    assert data["values"]["phase"]["max"] == e_max
+    assert data["values"]["phase"]["median"] == e_median
+    assert data["values"]["phase"]["quantile_25"] == e_q25
+    assert data["values"]["phase"]["quantile_75"] == e_q75
 
 
 @pytest.mark.parametrize("altitude_grp", [None, "alt_grp"])
 def test_update_results_written(altitude_grp):
     with transaction() as t:
         analytics.update_result(
-            t, [datetime.now()], phase, source, year, species, altitude_grp
+            t, [datetime.now()], PHASE, SOURCE, YEAR, SPECIES, altitude_grp
         )
 
-    write_data = read_result(altitude_grp=altitude_grp)
+    data = read_result(altitude_grp=altitude_grp)
 
     if altitude_grp is None:
-        assert "altitude_grp" not in write_data
+        assert "altitude_grp" not in data
     else:
-        assert write_data["altitude_grp"] == altitude_grp
-    assert write_data["source"] == source
-    assert write_data["year"] == year
-    assert write_data["species"] == species
+        assert data["altitude_grp"] == altitude_grp
+    assert data["source"] == SOURCE
+    assert data["year"] == YEAR
+    assert data["species"] == SPECIES
     assert (
-        k in write_data["values"]["phase"]
+        k in data["values"]["phase"]
         for k in ["min", "max", "median", "quantile_25", "quantile_75"]
     )
 
 
-def test_remove_observation(mocker, base_state_doc):
+def test_remove_observation(mocker, state_doc):
     update_result_mock = mocker.patch("phenoback.functions.analytics.update_result")
 
-    base_state_doc["state"] = {
+    state_doc["state"] = {
         "phase1": {"id": "value1", "another_id": "another_value1"},
         "phase2": {"id": "value2", "another_id": "another_value2"},
     }
-    write_state_doc(base_state_doc)
+    write_state(state_doc)
 
     with transaction() as t:
         analytics.remove_observation(
-            t, "id", year, species, "phase1", source, altitude_grp
+            t, "id", YEAR, SPECIES, "phase1", SOURCE, ALTITUDE_GRP
         )
 
     assert read_state()["state"] == {
@@ -344,18 +344,18 @@ def test_remove_observation(mocker, base_state_doc):
     assert update_result_mock.call_args[0][1] == ["another_value1"]
 
 
-def test_remove_observation_last_value(mocker, base_state_doc):
+def test_remove_observation_last_value(mocker, state_doc):
     update_result_mock = mocker.patch("phenoback.functions.analytics.update_result")
 
-    base_state_doc["state"] = {
+    state_doc["state"] = {
         "phase1": {"id": "value1", "another_id": "another_value1"},
         "phase2": {"id": "value2"},
     }
-    write_state_doc(base_state_doc)
+    write_state(state_doc)
 
     with transaction() as t:
         analytics.remove_observation(
-            t, "id", year, species, "phase2", source, altitude_grp
+            t, "id", YEAR, SPECIES, "phase2", SOURCE, ALTITUDE_GRP
         )
     assert read_state()["state"] == {
         "phase1": {"id": "value1", "another_id": "another_value1"}
@@ -375,13 +375,13 @@ def test_remove_observation_last_value(mocker, base_state_doc):
         },
     ],
 )
-def test_remove_data_not_exist(mocker, initial, base_state_doc):
+def test_remove_data_not_exist(mocker, initial, state_doc):
     analytics.log = mocker.Mock()
     update_result_mock = mocker.patch("phenoback.functions.analytics.update_result")
 
     if initial:
-        base_state_doc["state"] = initial
-        write_state_doc(base_state_doc)
+        state_doc["state"] = initial
+        write_state(state_doc)
 
     with transaction() as t:
         analytics.remove_observation(t, "id_not_exits", 0, "", "phase1", "")

--- a/test/test_analytics.py
+++ b/test/test_analytics.py
@@ -1,17 +1,30 @@
 # pylint: disable=too-many-arguments
 import copy
-from datetime import datetime
+from contextlib import contextmanager
+from datetime import timezone
 from unittest.mock import Mock
 
 import deepdiff
 import pytest
+from google.api_core.datetime_helpers import DatetimeWithNanoseconds as datetime
+from google.cloud.firestore_v1.transaction import transactional
 
 from phenoback.functions import analytics
 from phenoback.utils import firestore
+from phenoback.utils.firestore import get_document, write_document
 
 
 def _date(i: int) -> datetime:
-    return datetime(i, i, i, i)
+    return datetime(i, i, i, i, tzinfo=timezone.utc)
+
+
+observation_id = "id"
+source = "src"
+species = "species"
+phase = "phase"
+year = 2000
+altitude_grp = "grp"
+date = _date(1)
 
 
 def _data(write_document_mock: Mock) -> dict:
@@ -22,8 +35,16 @@ def _data(write_document_mock: Mock) -> dict:
     return write_document_mock.call_args[0][2]
 
 
-def _get_base_state_doc(source: str, species: str, year: int) -> dict:
-    return {"source": source, "species": species, "year": year, "state": {}}
+def _get_base_state_doc(
+    source: str = source,
+    species: str = species,
+    year: int = year,
+    altitude_grp: str = altitude_grp,
+) -> dict:
+    result = {"source": source, "species": species, "year": year, "state": {}}
+    if altitude_grp:
+        result["altitude_grp"] = altitude_grp
+    return result
 
 
 def _add_observation_to_state_doc(
@@ -35,29 +56,67 @@ def _add_observation_to_state_doc(
 
 @pytest.fixture()
 def base_state_doc():
-    return _get_base_state_doc("source", "species", 2020)
+    return _get_base_state_doc()
+
+
+@contextmanager
+def transaction():
+    transaction = firestore.get_transaction()
+    yield transaction
+    transaction.commit()
+
+
+def read_state(
+    year=year, species=species, source=source, altitude_grp=altitude_grp
+) -> dict:
+    return get_document(
+        analytics.STATE_COLLECTION,
+        analytics.get_analytics_document_id(year, species, source, altitude_grp),
+    )
+
+
+def read_result(
+    year=year, species=species, source=source, altitude_grp=altitude_grp
+) -> dict:
+    return get_document(
+        analytics.RESULT_COLLECTION,
+        analytics.get_analytics_document_id(year, species, source, altitude_grp),
+    )
+
+
+def write_state_doc(state_doc):
+    write_document(
+        analytics.STATE_COLLECTION,
+        analytics.get_analytics_document_id(
+            state_doc["year"],
+            state_doc["species"],
+            state_doc["source"],
+            state_doc.get("altitude_grp"),
+        ),
+        state_doc,
+    )
 
 
 @pytest.mark.parametrize("altitude_grp", [None, "alt_grp"])
-def test_update_state_initalized(mocker, altitude_grp):
-    mocker.patch("phenoback.functions.analytics.get_document", return_value=None)
-    write_document_mock = mocker.patch("phenoback.functions.analytics.write_document")
-    result_state = analytics.update_state(
-        "id", _date(1), "phase", "source", 1000, "species", altitude_grp
-    )
+def test_update_state_initalized(altitude_grp):
+    transactional_update_state = transactional(analytics.update_state)
+    with transaction() as t:
+        result_state = transactional_update_state(
+            t, observation_id, date, phase, source, year, species, altitude_grp
+        )
 
     # check written document
-    write_data = _data(write_document_mock)
+    write_data = read_state(year, species, source, altitude_grp)
     if altitude_grp is None:
         assert "altitude_grp" not in write_data
     else:
         assert write_data["altitude_grp"] == altitude_grp
-    assert write_data["source"] == "source"
-    assert write_data["year"] == 1000
-    assert write_data["species"] == "species"
-    assert write_data["state"]["phase"]["id"] == _date(1)
+    assert write_data["source"] == source
+    assert write_data["year"] == year
+    assert write_data["species"] == species
+    assert write_data["state"]["phase"][observation_id].date() == date.date()
     # check returned state
-    assert result_state[0] == _date(1)
+    assert result_state[0] == date
 
 
 @pytest.mark.parametrize(
@@ -71,8 +130,8 @@ def test_update_state_initalized(mocker, altitude_grp):
             {
                 "values_changed": {
                     "root['state']['phase1']['id1']": {
-                        "new_value": datetime(2, 2, 2, 2, 0),
-                        "old_value": datetime(1, 1, 1, 1, 0),
+                        "new_value": _date(2),
+                        "old_value": _date(1),
                     }
                 }
             },
@@ -80,29 +139,43 @@ def test_update_state_initalized(mocker, altitude_grp):
         ("id1", 1, "phase3", {"dictionary_item_added": ["root['state']['phase3']"]}),
     ],
 )
-def test_update_state_write(mocker, base_state_doc, obs_id, obs_date, phase, expected):
+def test_update_state_write(base_state_doc, obs_id, obs_date, phase, expected):
     _add_observation_to_state_doc(base_state_doc, "phase1", "id1", _date(1))
     _add_observation_to_state_doc(base_state_doc, "phase2", "id1", _date(2))
     _add_observation_to_state_doc(base_state_doc, "phase1", "id2", _date(3))
     _add_observation_to_state_doc(base_state_doc, "phase2", "id3", _date(4))
     base_state_ref = copy.deepcopy(base_state_doc)
 
-    mocker.patch(
-        "phenoback.functions.analytics.get_document", return_value=base_state_doc
+    write_document(
+        analytics.STATE_COLLECTION,
+        analytics.get_analytics_document_id(
+            base_state_doc["year"],
+            base_state_doc["species"],
+            base_state_doc["source"],
+            base_state_doc.get("altitude_grp"),
+        ),
+        base_state_doc,
     )
-    write_document_mock = mocker.patch("phenoback.functions.analytics.write_document")
+    transactional_update_state = transactional(analytics.update_state)
+    with transaction() as t:
+        transactional_update_state(
+            t,
+            obs_id,
+            _date(obs_date),
+            phase,
+            base_state_doc["source"],
+            base_state_doc["year"],
+            base_state_doc["species"],
+            base_state_doc.get("altitude_grp"),
+        )
 
-    analytics.update_state(
-        obs_id,
-        _date(obs_date),
-        phase,
-        base_state_doc["source"],
+    write_data = read_state(
         base_state_doc["year"],
         base_state_doc["species"],
+        base_state_doc["source"],
         base_state_doc.get("altitude_grp"),
     )
 
-    write_data = _data(write_document_mock)
     assert deepdiff.DeepDiff(base_state_ref, write_data) == expected, (
         base_state_ref,
         write_data,
@@ -119,7 +192,7 @@ def test_update_state_write(mocker, base_state_doc, obs_id, obs_date, phase, exp
     ],
 )
 def test_update_state_returned_states(
-    mocker, base_state_doc, initial_state, add_state, expected
+    base_state_doc, initial_state, add_state, expected
 ):
     initial_id = initial_state[0]
     initial_phase = initial_state[1]
@@ -127,58 +200,98 @@ def test_update_state_returned_states(
     add_phase = add_state[1]
     _add_observation_to_state_doc(base_state_doc, initial_phase, initial_id, _date(1))
 
-    mocker.patch(
-        "phenoback.functions.analytics.get_document", return_value=base_state_doc
-    )
-    mocker.patch("phenoback.functions.analytics.write_document")
-    result_state = analytics.update_state(add_id, _date(2), add_phase, "", 0, "")
+    write_state_doc(base_state_doc)
+
+    transactional_update_state = transactional(analytics.update_state)
+    with transaction() as t:
+        result_state = transactional_update_state(
+            t,
+            add_id,
+            _date(2),
+            add_phase,
+            base_state_doc["source"],
+            base_state_doc["year"],
+            base_state_doc["species"],
+            base_state_doc.get("altitude_grp"),
+        )
 
     assert len(result_state) == expected, (base_state_doc, result_state)
     assert _date(2) in result_state
 
 
-def test_update_results_no_dates(mocker):
-    write_document_mock = mocker.patch("phenoback.functions.analytics.write_document")
-    analytics.update_result([], "phase", "", 0, "", "")
-    write_data = _data(write_document_mock)
-    assert write_data["values"]["phase"] == firestore.DELETE_FIELD
+def test_update_results_no_dates():
+    with transaction() as t:
+        analytics.update_data(
+            t,
+            observation_id,
+            _date(2),
+            year,
+            species,
+            phase,
+            source,
+            altitude_grp,
+        )
+
+    # check the phase is present
+    assert read_result()["values"][phase]
+
+    with transaction() as t:
+        analytics.update_result(t, [], phase, source, year, species, altitude_grp)
+
+    # assert phase was deleted with the last value
+    assert not read_result()["values"].get(phase)
 
 
 @pytest.mark.parametrize(
     "state, e_min, e_max, e_median, e_q25, e_q75",
     [
         (
-            [datetime(2020, 1, 1)],
-            datetime(2020, 1, 1),
-            datetime(2020, 1, 1),
-            datetime(2020, 1, 1),
-            datetime(2020, 1, 1),
-            datetime(2020, 1, 1),
+            [datetime(2020, 1, 1, tzinfo=timezone.utc)],
+            datetime(2020, 1, 1, tzinfo=timezone.utc),
+            datetime(2020, 1, 1, tzinfo=timezone.utc),
+            datetime(2020, 1, 1, tzinfo=timezone.utc),
+            datetime(2020, 1, 1, tzinfo=timezone.utc),
+            datetime(2020, 1, 1, tzinfo=timezone.utc),
         ),
         (
-            [datetime(2020, 1, 1), datetime(2020, 1, 3)],
-            datetime(2020, 1, 1),
-            datetime(2020, 1, 3),
-            datetime(2020, 1, 1),
-            datetime(2020, 1, 1),
-            datetime(2020, 1, 3),
+            [
+                datetime(2020, 1, 1, tzinfo=timezone.utc),
+                datetime(2020, 1, 3, tzinfo=timezone.utc),
+            ],
+            datetime(2020, 1, 1, tzinfo=timezone.utc),
+            datetime(2020, 1, 3, tzinfo=timezone.utc),
+            datetime(2020, 1, 1, tzinfo=timezone.utc),
+            datetime(2020, 1, 1, tzinfo=timezone.utc),
+            datetime(2020, 1, 3, tzinfo=timezone.utc),
         ),
         (
-            [datetime(2020, 1, 1), datetime(2020, 1, 3), datetime(2020, 1, 4)],
-            datetime(2020, 1, 1),
-            datetime(2020, 1, 4),
-            datetime(2020, 1, 3),
-            datetime(2020, 1, 1),
-            datetime(2020, 1, 4),
+            [
+                datetime(2020, 1, 1, tzinfo=timezone.utc),
+                datetime(2020, 1, 3, tzinfo=timezone.utc),
+                datetime(2020, 1, 4, tzinfo=timezone.utc),
+            ],
+            datetime(2020, 1, 1, tzinfo=timezone.utc),
+            datetime(2020, 1, 4, tzinfo=timezone.utc),
+            datetime(2020, 1, 3, tzinfo=timezone.utc),
+            datetime(2020, 1, 1, tzinfo=timezone.utc),
+            datetime(2020, 1, 4, tzinfo=timezone.utc),
         ),
     ],
 )
-def test_update_results_calculation(
-    mocker, state, e_min, e_max, e_median, e_q25, e_q75
-):
-    write_document_mock = mocker.patch("phenoback.functions.analytics.write_document")
-    analytics.update_result(state, "phase", "", 0, "", "")
-    write_data = _data(write_document_mock)
+def test_update_results_calculation(state, e_min, e_max, e_median, e_q25, e_q75):
+    source = "src"
+    species = "species"
+    phase = "phase"
+    year = 2000
+    altitude_grp = "grp"
+    transactional_update_result = transactional(analytics.update_result)
+    with transaction() as t:
+        transactional_update_result(
+            t, state, phase, source, year, species, altitude_grp
+        )
+
+    write_data = read_result()
+
     assert write_data["values"]["phase"]["min"] == e_min
     assert write_data["values"]["phase"]["max"] == e_max
     assert write_data["values"]["phase"]["median"] == e_median
@@ -187,88 +300,93 @@ def test_update_results_calculation(
 
 
 @pytest.mark.parametrize("altitude_grp", [None, "alt_grp"])
-def test_update_results_written(mocker, altitude_grp):
-    write_document_mock = mocker.patch("phenoback.functions.analytics.write_document")
-    analytics.update_result(
-        [datetime.now()], "phase", "source", 10, "species", altitude_grp
-    )
-    write_data = _data(write_document_mock)
+def test_update_results_written(altitude_grp):
+    with transaction() as t:
+        analytics.update_result(
+            t, [datetime.now()], phase, source, year, species, altitude_grp
+        )
+
+    write_data = read_result(altitude_grp=altitude_grp)
+
     if altitude_grp is None:
         assert "altitude_grp" not in write_data
     else:
         assert write_data["altitude_grp"] == altitude_grp
-    assert write_data["source"] == "source"
-    assert write_data["year"] == 10
-    assert write_data["species"] == "species"
-    assert write_data["source"] == "source"
+    assert write_data["source"] == source
+    assert write_data["year"] == year
+    assert write_data["species"] == species
     assert (
         k in write_data["values"]["phase"]
         for k in ["min", "max", "median", "quantile_25", "quantile_75"]
     )
-    assert write_document_mock.call_args[1].get("merge")
 
 
-def test_remove_observation(mocker):
-    inital = {
-        "state": {
-            "phase1": {"id": "value1", "another_id": "another_value1"},
-            "phase2": {"id": "value2", "another_id": "another_value2"},
-        }
-    }
-    mocker.patch("phenoback.functions.analytics.get_document", return_value=inital)
-    write_document_mock = mocker.patch("phenoback.functions.analytics.write_document")
+def test_remove_observation(mocker, base_state_doc):
     update_result_mock = mocker.patch("phenoback.functions.analytics.update_result")
-    analytics.remove_observation("id", 0, "", "phase1", "")
-    assert _data(write_document_mock) == {
-        "state": {
-            "phase1": {"another_id": "another_value1"},
-            "phase2": {"id": "value2", "another_id": "another_value2"},
-        }
+
+    base_state_doc["state"] = {
+        "phase1": {"id": "value1", "another_id": "another_value1"},
+        "phase2": {"id": "value2", "another_id": "another_value2"},
     }
-    assert update_result_mock.call_args[0][0] == ["another_value1"]
+    write_state_doc(base_state_doc)
+
+    with transaction() as t:
+        analytics.remove_observation(
+            t, "id", year, species, "phase1", source, altitude_grp
+        )
+
+    assert read_state()["state"] == {
+        "phase1": {"another_id": "another_value1"},
+        "phase2": {"id": "value2", "another_id": "another_value2"},
+    }
+
+    print(update_result_mock.call_args)
+    assert update_result_mock.call_args[0][1] == ["another_value1"]
 
 
-@pytest.mark.skip('No clue why the mock contains "phase2"')
-def test_remove_observation_last_value(mocker):
-    inital = {
-        "state": {
-            "phase1": {"id": "value1", "another_id": "another_value1"},
-            "phase2": {"id": "value2"},
-        }
-    }
-    mocker.patch("phenoback.functions.analytics.get_document", return_value=inital)
-    write_document_mock = mocker.patch("phenoback.functions.analytics.write_document")
+def test_remove_observation_last_value(mocker, base_state_doc):
     update_result_mock = mocker.patch("phenoback.functions.analytics.update_result")
-    analytics.remove_observation("id", 0, "", "phase2", "")
-    assert _data(write_document_mock) == {
-        "state": {"phase1": {"id": "value1", "another_id": "another_value1"}}
+
+    base_state_doc["state"] = {
+        "phase1": {"id": "value1", "another_id": "another_value1"},
+        "phase2": {"id": "value2"},
     }
-    assert update_result_mock.call_args[0][0] == []
+    write_state_doc(base_state_doc)
+
+    with transaction() as t:
+        analytics.remove_observation(
+            t, "id", year, species, "phase2", source, altitude_grp
+        )
+    assert read_state()["state"] == {
+        "phase1": {"id": "value1", "another_id": "another_value1"}
+    }
+
+    assert update_result_mock.call_args[0][1] == []
 
 
 @pytest.mark.parametrize(
     "initial",
     [
-        {},
         None,
+        {},
         {
-            "state": {
-                "phase1": {"id": "value1", "another_id": "another_value1"},
-                "phase2": {"id": "value2", "another_id": "another_value2"},
-            }
+            "phase1": {"id": "value1", "another_id": "another_value1"},
+            "phase2": {"id": "value2", "another_id": "another_value2"},
         },
     ],
 )
-def test_remove_data_not_exist(mocker, initial):
-    mocker.patch("phenoback.functions.analytics.get_document", return_value=initial)
-    write_document_mock = mocker.patch("phenoback.functions.analytics.write_document")
-    update_result_mock = mocker.patch("phenoback.functions.analytics.update_result")
+def test_remove_data_not_exist(mocker, initial, base_state_doc):
     analytics.log = mocker.Mock()
+    update_result_mock = mocker.patch("phenoback.functions.analytics.update_result")
 
-    analytics.remove_observation("id_not_exits", 0, "", "phase1", "")
+    if initial:
+        base_state_doc["state"] = initial
+        write_state_doc(base_state_doc)
+
+    with transaction() as t:
+        analytics.remove_observation(t, "id_not_exits", 0, "", "phase1", "")
 
     analytics.log.error.assert_called()
-    write_document_mock.assert_not_called()
     update_result_mock.assert_not_called()
 
 


### PR DESCRIPTION
Process statistic calculation to a transaction to prevent missing data on simultaneous writes. The functions will now trigger an error if the transaction fails 5 times.

closes #54 
