### PR TITLE
make user changes transactional

### DIFF
--- a/phenoback/functions/analytics.py
+++ b/phenoback/functions/analytics.py
@@ -3,10 +3,14 @@ from datetime import datetime
 from typing import Optional
 
 import numpy as np
-from google.cloud import firestore
 
 from phenoback.utils.data import get_individual
-from phenoback.utils.firestore import DELETE_FIELD, firestore_client, Transaction
+from phenoback.utils.firestore import (
+    DELETE_FIELD,
+    Transaction,
+    firestore_client,
+    transactional,
+)
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.INFO)
@@ -111,7 +115,7 @@ def update_result(
     transaction.set(result_ref, result_document, merge=True)
 
 
-@firestore.transactional
+@transactional
 def update_data(
     transaction: Transaction,
     observation_id: str,
@@ -137,7 +141,7 @@ def update_data(
     )
 
 
-@firestore.transactional
+@transactional
 def remove_observation(
     transaction: Transaction,
     observation_id: str,

--- a/phenoback/functions/users.py
+++ b/phenoback/functions/users.py
@@ -1,17 +1,43 @@
-from phenoback.utils.firestore import delete_document, update_document, write_document
+from phenoback.utils.firestore import (
+    delete_document,
+    transaction,
+    transactional,
+    update_document,
+    write_document,
+)
 
 
-def process_new_user(user_id: str, nickname: str):
-    write_document("nicknames", nickname, {"user": user_id})
-    write_document("public_users", user_id, {"nickname": nickname})
+def process_new_user(user_id: str, nickname: str) -> None:
+    with transaction() as trx:
+        _process_new_user_trx(trx, user_id, nickname)
 
 
-def process_update_nickname(user_id: str, nickname_old: str, nickname_new: str):
-    write_document("nicknames", nickname_new, {"user": user_id})
-    update_document("public_users", user_id, {"nickname": nickname_new})
-    delete_document("nicknames", nickname_old)
+@transactional
+def _process_new_user_trx(trx, user_id, nickname):
+    write_document("nicknames", nickname, {"user": user_id}, transaction=trx)
+    write_document("public_users", user_id, {"nickname": nickname}, transaction=trx)
 
 
-def process_delete_user(user_id: str, nickname: str):
-    delete_document("nicknames", nickname)
-    delete_document("public_users", user_id)
+def process_update_nickname(user_id: str, nickname_old: str, nickname_new: str) -> None:
+    with transaction() as trx:
+        _process_update_nickname_trx(trx, user_id, nickname_old, nickname_new)
+
+
+@transactional
+def _process_update_nickname_trx(trx, user_id, nickname_old, nickname_new):
+    write_document("nicknames", nickname_new, {"user": user_id}, transaction=trx)
+    update_document(
+        "public_users", user_id, {"nickname": nickname_new}, transaction=trx
+    )
+    delete_document("nicknames", nickname_old, transaction=trx)
+
+
+def process_delete_user(user_id: str, nickname: str) -> None:
+    with transaction() as trx:
+        _process_delete_user_trx(trx, user_id, nickname)
+
+
+@transactional
+def _process_delete_user_trx(trx, user_id, nickname):
+    delete_document("nicknames", nickname, transaction=trx)
+    delete_document("public_users", user_id, transaction=trx)

--- a/phenoback/utils/firestore.py
+++ b/phenoback/utils/firestore.py
@@ -1,4 +1,5 @@
 import logging
+from contextlib import contextmanager
 from typing import Any, List, Optional
 
 from firebase_admin import firestore
@@ -7,12 +8,12 @@ from google.cloud.firestore_v1 import SERVER_TIMESTAMP as _SERVER_TIMESTAMP
 from google.cloud.firestore_v1 import ArrayUnion as _ArrayUnion
 from google.cloud.firestore_v1 import Increment as _Increment
 from google.cloud.firestore_v1 import Query as _Query
+from google.cloud.firestore_v1 import transactional as _transactional
 from google.cloud.firestore_v1.client import Client as _Client
 from google.cloud.firestore_v1.collection import (
     CollectionReference as _CollectionReference,
 )
 from google.cloud.firestore_v1.transaction import Transaction as _Transaction
-from google.cloud.firestore_v1 import transactional as _transactional
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.INFO)
@@ -40,6 +41,13 @@ def firestore_client() -> Client:
 
 def get_transaction():
     return firestore_client().transaction()
+
+
+@contextmanager
+def transaction():
+    transaction = get_transaction()
+    yield transaction
+    transaction.commit()
 
 
 def delete_document(

--- a/phenoback/utils/firestore.py
+++ b/phenoback/utils/firestore.py
@@ -12,6 +12,7 @@ from google.cloud.firestore_v1.collection import (
     CollectionReference as _CollectionReference,
 )
 from google.cloud.firestore_v1.transaction import Transaction as _Transaction
+from google.cloud.firestore_v1 import transactional as _transactional
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.INFO)
@@ -27,6 +28,7 @@ Query = _Query
 Client = _Client
 CollectionReference = _CollectionReference
 Transaction = _Transaction
+transactional = _transactional
 
 
 def firestore_client() -> Client:

--- a/test/test_analytics.py
+++ b/test/test_analytics.py
@@ -1,6 +1,5 @@
 # pylint: disable=too-many-arguments
 import copy
-from contextlib import contextmanager
 from datetime import timezone
 from unittest.mock import Mock
 
@@ -10,8 +9,7 @@ from google.api_core.datetime_helpers import DatetimeWithNanoseconds as datetime
 from google.cloud.firestore_v1.transaction import transactional
 
 from phenoback.functions import analytics
-from phenoback.utils import firestore
-from phenoback.utils.firestore import get_document, write_document
+from phenoback.utils.firestore import get_document, transaction, write_document
 
 
 def _date(i: int) -> datetime:
@@ -55,13 +53,6 @@ def add_state(state_doc: dict, phase: str, observation_id: str, date: datetime) 
 @pytest.fixture()
 def state_doc():
     return get_state_doc()
-
-
-@contextmanager
-def transaction():
-    transaction = firestore.get_transaction()
-    yield transaction
-    transaction.commit()
 
 
 def read_state(

--- a/test/test_firestore.py
+++ b/test/test_firestore.py
@@ -5,10 +5,10 @@ from typing import Dict
 
 import google.api_core.exceptions
 import pytest
-from google.cloud import firestore
 from google.cloud.firestore_v1._helpers import ReadAfterWriteError
 
 from phenoback.utils import firestore as f
+from phenoback.utils.firestore import transactional
 
 
 def get_random_string(length) -> str:
@@ -177,7 +177,7 @@ def test_delete_batch(collection):
 
 
 def test_write_document__transaction(collection, doc_id, doc):
-    @firestore.transactional
+    @transactional
     def write_transactional(
         transaction,
         collection,
@@ -191,7 +191,7 @@ def test_write_document__transaction(collection, doc_id, doc):
 
 
 def test_update_document__transaction(collection, doc_id, doc, doc2):
-    @firestore.transactional
+    @transactional
     def update_transactional(
         transaction,
         collection,
@@ -208,7 +208,7 @@ def test_update_document__transaction(collection, doc_id, doc, doc2):
 
 
 def test_delete_document__transaction(collection, doc_id, doc):
-    @firestore.transactional
+    @transactional
     def delete_transactional(
         transaction,
         collection,
@@ -224,7 +224,7 @@ def test_delete_document__transaction(collection, doc_id, doc):
 
 
 def test_get_document__transaction(collection, doc_id, doc):
-    @firestore.transactional
+    @transactional
     def get_transactional(
         transaction,
         collection,
@@ -238,7 +238,7 @@ def test_get_document__transaction(collection, doc_id, doc):
 
 
 def test_get_document__transaction_fail(collection, doc_id, doc):
-    @firestore.transactional
+    @transactional
     def transactional__fail(transaction, collection, doc_id):
         f.write_document(collection, doc_id, doc, transaction=transaction)
         f.get_document(collection, doc_id, transaction=transaction)

--- a/test/test_firestore.py
+++ b/test/test_firestore.py
@@ -1,6 +1,5 @@
 import random
 import string
-from contextlib import contextmanager
 from typing import Dict
 
 import google.api_core.exceptions
@@ -8,7 +7,7 @@ import pytest
 from google.cloud.firestore_v1._helpers import ReadAfterWriteError
 
 from phenoback.utils import firestore as f
-from phenoback.utils.firestore import transactional
+from phenoback.utils.firestore import transaction, transactional
 
 
 def get_random_string(length) -> str:
@@ -16,13 +15,6 @@ def get_random_string(length) -> str:
     letters = string.ascii_letters
     result_str = "".join(random.choice(letters) for i in range(length))  # nosec (B312)
     return result_str
-
-
-@contextmanager
-def transaction():
-    transaction = f.get_transaction()
-    yield transaction
-    transaction.commit()
 
 
 @pytest.fixture()

--- a/test/test_users.py
+++ b/test/test_users.py
@@ -1,41 +1,45 @@
-from unittest.mock import call
+import pytest
 
 from phenoback.functions import users
+from phenoback.utils import firestore as f
 
 
-def test_new_user(mocker):
-    write_mock = mocker.patch("phenoback.functions.users.write_document")
-
-    users.process_new_user("user_id", "nickname")
-
-    assert write_mock.call_args_list == [
-        call("nicknames", "nickname", {"user": "user_id"}),
-        call("public_users", "user_id", {"nickname": "nickname"}),
-    ]
+@pytest.fixture()
+def user_id():
+    return "user_id"
 
 
-def test_update_nickname(mocker):
-    write_mock = mocker.patch("phenoback.functions.users.write_document")
-    update_mock = mocker.patch("phenoback.functions.users.update_document")
-    delete_mock = mocker.patch("phenoback.functions.users.delete_document")
-
-    users.process_update_nickname("user_id", "nickname_old", "nickname_new")
-
-    assert write_mock.call_args == call(
-        "nicknames", "nickname_new", {"user": "user_id"}
-    )
-    assert update_mock.call_args == call(
-        "public_users", "user_id", {"nickname": "nickname_new"}
-    )
-    assert delete_mock.call_args == call("nicknames", "nickname_old")
+@pytest.fixture()
+def nickname():
+    return "nick1"
 
 
-def test_delete_user(mocker):
-    delete_mock = mocker.patch("phenoback.functions.users.delete_document")
+@pytest.fixture()
+def nickname2():
+    return "nick2"
 
-    users.process_delete_user("user_id", "nickname")
 
-    assert delete_mock.call_args_list == [
-        call("nicknames", "nickname"),
-        call("public_users", "user_id"),
-    ]
+def test_new_user(user_id, nickname):
+    users.process_new_user(user_id, nickname)
+
+    assert f.get_document("public_users", user_id).get("nickname") == nickname
+    assert f.get_document("nicknames", nickname).get("user") == user_id
+
+
+def test_update_nickname(user_id, nickname, nickname2):
+    users.process_new_user(user_id, nickname)
+
+    users.process_update_nickname(user_id, nickname, nickname2)
+
+    assert f.get_document("public_users", user_id).get("nickname") == nickname2
+    assert f.get_document("nicknames", nickname) is None
+    assert f.get_document("nicknames", nickname2).get("user") == user_id
+
+
+def test_delete_user(user_id, nickname):
+    users.process_new_user(user_id, nickname)
+
+    users.process_delete_user(user_id, nickname)
+
+    assert f.get_document("public_users", user_id) is None
+    assert f.get_document("nicknames", nickname) is None


### PR DESCRIPTION
user changes are wrapped in a transaction to prevent inconsistent states between the users collections.

closes #65 