### PR TITLE
update map on reprocess field

### DIFF
--- a/phenoback/functions/map.py
+++ b/phenoback/functions/map.py
@@ -89,6 +89,7 @@ def _should_update(updated_fields: List[str]) -> bool:
             "deveui",
             "type",
             "species",
+            "reprocess",
         ]
         for elem in updated_fields
     )

--- a/test/functions/test_map.py
+++ b/test/functions/test_map.py
@@ -201,6 +201,7 @@ def test_process_change__new_value(mapdata, initialdata: dict):
         (["deveui"], True),
         (["source", "other_values"], True),
         (["other_values"], False),
+        (["reprocess"], True),
     ],
 )
 def test_should_update(updated_fields, expected):


### PR DESCRIPTION
allow reprocessing of maps collection by modifying "reprocess" field on individuals.

relates to #146 