### PR TITLE
fix: enqueue created individuals on map tasks

### DIFF
--- a/phenoback/functions/map.py
+++ b/phenoback/functions/map.py
@@ -80,15 +80,17 @@ def enqueue_change(
         payload = {"year": year, "values": values}
         client().send(payload)
         log.info(
-            "enqueue task for change on %s: fields=%s",
+            "enqueue task for change on %s: fields=%s, created=%s",
             individual_id,
             updated_fields,
+            is_create_event,
         )
     else:
         log.debug(
-            "nothing to do for change on %s: fields=%s",
+            "nothing to do for change on %s: fields=%s, created=%s",
             individual_id,
             updated_fields,
+            is_create_event,
         )
 
 

--- a/phenoback/functions/map.py
+++ b/phenoback/functions/map.py
@@ -31,6 +31,7 @@ def main_enqueue(data, context):
             g.get_field(data, "source"),
             g.get_field(data, "year"),
             g.get_field(data, "deveui", expected=False),
+            g.is_create_event(data),
         )
     else:
         delete(g.get_field(data, "year", old_value=True), g.get_document_id(context))
@@ -57,8 +58,9 @@ def enqueue_change(
     source: str,
     year: int,
     deveui: str,
+    is_create_event: bool,
 ) -> None:
-    if _should_update(updated_fields):
+    if _should_update(updated_fields, is_create_event):
         values = {
             individual_id: {
                 "t": individual_type,
@@ -104,8 +106,8 @@ def replace_delete_tokens(payload: dict) -> None:
             individual_dict[key] = f.DELETE_FIELD if value == DELETE_TOKEN else value
 
 
-def _should_update(updated_fields: List[str]) -> bool:
-    return any(
+def _should_update(updated_fields: List[str], is_create_event: bool) -> bool:
+    return is_create_event or any(
         elem
         in [
             "geopos.lat",

--- a/test/functions/test_map.py
+++ b/test/functions/test_map.py
@@ -63,6 +63,7 @@ def test_enqueue_change__should_update(mocker, should_update):
         "source",
         2020,
         "deveui",
+        False,
     )
 
     assert should_update_mock.called_with(["updated_fields"])
@@ -87,6 +88,7 @@ def test_enqueue_change__values(mocker):
         "source",
         2020,
         "deveui",
+        False,
     )
 
     client_mock.return_value.send.assert_called_with(
@@ -122,6 +124,7 @@ def test_enqueue_change__optional_fields_delete(mocker):
         "source",
         2020,
         None,
+        False,
     )
 
     client_mock.return_value.send.assert_called_with(
@@ -193,23 +196,24 @@ def test_process_change__new_value(mapdata, initialdata: dict):
 
 
 @pytest.mark.parametrize(
-    "updated_fields, expected",
+    "updated_fields, is_create_event, expected",
     [
-        (["geopos.lat"], True),
-        (["geopos.lng"], True),
-        (["station_species"], True),
-        (["species"], True),
-        (["type"], True),
-        (["last_phenophase"], True),
-        (["source"], True),
-        (["deveui"], True),
-        (["source", "other_values"], True),
-        (["other_values"], False),
-        (["reprocess"], True),
+        (["geopos.lat"], False, True),
+        (["geopos.lng"], False, True),
+        (["station_species"], False, True),
+        (["species"], False, True),
+        (["type"], False, True),
+        (["last_phenophase"], False, True),
+        (["source"], False, True),
+        (["deveui"], False, True),
+        (["source", "other_values"], False, True),
+        (["other_values"], False, False),
+        (["other_values"], True, True),
+        (["reprocess"], False, True),
     ],
 )
-def test_should_update(updated_fields, expected):
-    assert pheno_map._should_update(updated_fields) == expected
+def test_should_update(updated_fields, is_create_event, expected):
+    assert pheno_map._should_update(updated_fields, is_create_event) == expected
 
 
 def test_delete(mapdata):


### PR DESCRIPTION
fix the issue that the map collection was not updated if full datasets are imported (wld) and not updated over time.