### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/copyback.yml
+++ b/.github/workflows/copyback.yml
@@ -19,10 +19,10 @@ jobs:
       fs-functions: ${{ steps.fs-functions.outputs.functions }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.5
+        uses: actions/checkout@v4.1.7
       - id: auth
         name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2.1.2
+        uses: google-github-actions/auth@v2.1.3
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
@@ -45,10 +45,10 @@ jobs:
         function: ${{ fromJson(needs.fs-function-matrix.outputs.fs-functions) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.5
+        uses: actions/checkout@v4.1.7
       - id: auth
         name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2.1.2
+        uses: google-github-actions/auth@v2.1.3
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
@@ -64,7 +64,7 @@ jobs:
     environment: phaenonet-test
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.5
+        uses: actions/checkout@v4.1.7
       - name: Setup Node ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v4.0.2
         with:
@@ -73,7 +73,7 @@ jobs:
         run: npm i -g firebase-tools
       - id: auth
         name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2.1.2
+        uses: google-github-actions/auth@v2.1.3
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_BACKUP_ACCOUNT }}
@@ -86,10 +86,10 @@ jobs:
     environment: phaenonet-test
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.5
+        uses: actions/checkout@v4.1.7
       - id: auth
         name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2.1.2
+        uses: google-github-actions/auth@v2.1.3
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_BACKUP_ACCOUNT }}
@@ -108,7 +108,7 @@ jobs:
       actions: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.5
+        uses: actions/checkout@v4.1.7
       - name: trigger function installation
         run: gh workflow run -f function=all "deploy cloud functions"
         env:
@@ -118,6 +118,6 @@ jobs:
     needs: install-functions
     steps:
       - name: call restore function
-        uses: fjogeleit/http-request-action@v1.15.5
+        uses: fjogeleit/http-request-action@v1.16.1
         with:
           url: "https://europe-west1-phaenonet-test.cloudfunctions.net/e2e_restore_users"

--- a/.github/workflows/deploy-function.yml
+++ b/.github/workflows/deploy-function.yml
@@ -144,12 +144,12 @@ jobs:
       VERSION: "${{ matrix.name }}@${{ github.event.inputs.tag && github.event.inputs.tag || github.sha }}"
     environment: ${{ github.event.inputs.project }}
     steps:
-      - uses: actions/checkout@v4.1.5
+      - uses: actions/checkout@v4.1.7
       - name: Work around https://github.com/actions/checkout/issues/766
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - id: auth
         name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2.1.2
+        uses: google-github-actions/auth@v2.1.3
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     container: globeswiss/cloud-sdk:py3.12.2-463.0.0
     steps:
-      - uses: actions/checkout@v4.1.5
+      - uses: actions/checkout@v4.1.7
       - name: Install dependencies
         run: pip3 install pipenv
       - name: Sync dev dependencies
@@ -38,14 +38,14 @@ jobs:
       #     fail_on_error: True
       #   if: always()
       - name: Check black
-        uses: reviewdog/action-black@v3.15.0
+        uses: reviewdog/action-black@v3.16.2
         with:
           reporter: github-check
           verbose: True
           fail_on_error: True
         if: always()
       - name: Check markdownlint
-        uses: reviewdog/action-markdownlint@v0.18.0
+        uses: reviewdog/action-markdownlint@v0.20.0
         with:
           reporter: github-check
           fail_on_error: True
@@ -54,7 +54,7 @@ jobs:
         run: pipenv run python -m pytest --cov-report xml --cov=main --cov=phenoback --cov-branch
         if: always()
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4.3.1
+        uses: codecov/codecov-action@v4.4.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     container: globeswiss/cloud-sdk:py3.12.2-463.0.0
     steps:
-      - uses: actions/checkout@v4.1.5
+      - uses: actions/checkout@v4.1.7
       - name: install dependencies
         run: pip3 install pipenv
       - name: Update pipenv environment

--- a/.github/workflows/version-updater.yml
+++ b/.github/workflows/version-updater.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.1.5
+      - uses: actions/checkout@v4.1.7
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_ACCESS_TOKEN }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[fjogeleit/http-request-action](https://github.com/fjogeleit/http-request-action)** published a new release **[v1.16.1](https://github.com/fjogeleit/http-request-action/releases/tag/v1.16.1)** on 2024-06-04T20:46:04Z
* **[reviewdog/action-markdownlint](https://github.com/reviewdog/action-markdownlint)** published a new release **[v0.20.0](https://github.com/reviewdog/action-markdownlint/releases/tag/v0.20.0)** on 2024-06-08T09:49:55Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.1.7](https://github.com/actions/checkout/releases/tag/v4.1.7)** on 2024-06-12T19:05:21Z
* **[google-github-actions/auth](https://github.com/google-github-actions/auth)** published a new release **[v2.1.3](https://github.com/google-github-actions/auth/releases/tag/v2.1.3)** on 2024-05-14T17:58:05Z
* **[codecov/codecov-action](https://github.com/codecov/codecov-action)** published a new release **[v4.4.1](https://github.com/codecov/codecov-action/releases/tag/v4.4.1)** on 2024-05-20T14:11:05Z
* **[reviewdog/action-black](https://github.com/reviewdog/action-black)** published a new release **[v3.16.2](https://github.com/reviewdog/action-black/releases/tag/v3.16.2)** on 2024-06-13T11:24:08Z
