### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,14 +38,14 @@ jobs:
       #     fail_on_error: True
       #   if: always()
       - name: Check black
-        uses: reviewdog/action-black@v3.17.0
+        uses: reviewdog/action-black@v3.18.0
         with:
           reporter: github-check
           verbose: True
           fail_on_error: True
         if: always()
       - name: Check markdownlint
-        uses: reviewdog/action-markdownlint@v0.21.0
+        uses: reviewdog/action-markdownlint@v0.22.0
         with:
           reporter: github-check
           fail_on_error: True


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[reviewdog/action-black](https://github.com/reviewdog/action-black)** published a new release **[v3.18.0](https://github.com/reviewdog/action-black/releases/tag/v3.18.0)** on 2024-06-22T15:58:56Z
* **[reviewdog/action-markdownlint](https://github.com/reviewdog/action-markdownlint)** published a new release **[v0.22.0](https://github.com/reviewdog/action-markdownlint/releases/tag/v0.22.0)** on 2024-06-23T07:02:27Z
