### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/copyback.yml
+++ b/.github/workflows/copyback.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.1.7
       - name: Setup Node ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4.0.2
+        uses: actions/setup-node@v4.0.3
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: install firebase-tools

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,14 +38,14 @@ jobs:
       #     fail_on_error: True
       #   if: always()
       - name: Check black
-        uses: reviewdog/action-black@v3.18.0
+        uses: reviewdog/action-black@v3.19.0
         with:
           reporter: github-check
           verbose: True
           fail_on_error: True
         if: always()
       - name: Check markdownlint
-        uses: reviewdog/action-markdownlint@v0.22.0
+        uses: reviewdog/action-markdownlint@v0.23.0
         with:
           reporter: github-check
           fail_on_error: True


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v4.0.3](https://github.com/actions/setup-node/releases/tag/v4.0.3)** on 2024-07-09T14:22:34Z
* **[reviewdog/action-black](https://github.com/reviewdog/action-black)** published a new release **[v3.19.0](https://github.com/reviewdog/action-black/releases/tag/v3.19.0)** on 2024-07-07T00:24:40Z
* **[reviewdog/action-markdownlint](https://github.com/reviewdog/action-markdownlint)** published a new release **[v0.23.0](https://github.com/reviewdog/action-markdownlint/releases/tag/v0.23.0)** on 2024-07-07T00:25:27Z
