### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,14 +42,14 @@ jobs:
       #     fail_on_error: True
       #   if: always()
       - name: Check black
-        uses: reviewdog/action-black@v3.19.0
+        uses: reviewdog/action-black@v3.20.0
         with:
           reporter: github-check
           verbose: True
           fail_on_error: True
         if: always()
       - name: Check markdownlint
-        uses: reviewdog/action-markdownlint@v0.23.0
+        uses: reviewdog/action-markdownlint@v0.24.0
         with:
           reporter: github-check
           fail_on_error: True


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[reviewdog/action-markdownlint](https://github.com/reviewdog/action-markdownlint)** published a new release **[v0.24.0](https://github.com/reviewdog/action-markdownlint/releases/tag/v0.24.0)** on 2024-07-14T12:55:20Z
* **[reviewdog/action-black](https://github.com/reviewdog/action-black)** published a new release **[v3.20.0](https://github.com/reviewdog/action-black/releases/tag/v3.20.0)** on 2024-07-14T12:54:33Z
