### PR TITLE
optimize enqueuing map changes

### DIFF
--- a/phenoback/functions/map.py
+++ b/phenoback/functions/map.py
@@ -59,7 +59,9 @@ def enqueue_change(
     deveui: str,
     is_create_event: bool,
 ) -> None:
-    if _should_update(updated_fields, is_create_event):
+    if _should_update(
+        updated_fields, is_create_event, station_species, last_phenophase
+    ):
         values = {
             individual_id: {
                 "t": individual_type,
@@ -107,8 +109,17 @@ def replace_delete_tokens(payload: dict) -> None:
             individual_dict[key] = f.DELETE_FIELD if value == DELETE_TOKEN else value
 
 
-def _should_update(updated_fields: list[str], is_create_event: bool) -> bool:
-    return is_create_event or any(
+def _should_update(
+    updated_fields: list[str], is_create_event: bool, station_species, last_phenophase
+) -> bool:
+    """
+    Update if
+    * a new individual/station is created which would be shown on the map
+    * data is updated that is relevant on the map
+    """
+    return (
+        is_create_event and (station_species is not None or last_phenophase is not None)
+    ) or any(
         elem
         in [
             "geopos.lat",

--- a/test/functions/test_map.py
+++ b/test/functions/test_map.py
@@ -66,7 +66,9 @@ def test_enqueue_change__should_update(mocker, should_update):
         False,
     )
 
-    should_update_mock.assert_called_with(["updated_fields"], False)
+    should_update_mock.assert_called_with(
+        ["updated_fields"], False, ["station_species"], "last_phenophase"
+    )
     if should_update:
         client_mock.return_value.send.assert_called()
     else:
@@ -196,24 +198,37 @@ def test_process_change__new_value(mapdata, initialdata: dict):
 
 
 @pytest.mark.parametrize(
-    "updated_fields, is_create_event, expected",
+    "station_species, last_phenophase, expected",
     [
-        (["geopos.lat"], False, True),
-        (["geopos.lng"], False, True),
-        (["station_species"], False, True),
-        (["species"], False, True),
-        (["type"], False, True),
-        (["last_phenophase"], False, True),
-        (["source"], False, True),
-        (["deveui"], False, True),
-        (["source", "other_values"], False, True),
-        (["other_values"], False, False),
-        (["other_values"], True, True),
-        (["reprocess"], False, True),
+        (["HS"], None, True),
+        (None, "BLA", True),
+        (None, None, False),
     ],
 )
-def test_should_update(updated_fields, is_create_event, expected):
-    assert pheno_map._should_update(updated_fields, is_create_event) == expected
+def test_should_update__on_create(station_species, last_phenophase, expected):
+    assert (
+        pheno_map._should_update([], True, station_species, last_phenophase) == expected
+    )
+
+
+@pytest.mark.parametrize(
+    "updated_fields, expected",
+    [
+        (["geopos.lat"], True),
+        (["geopos.lng"], True),
+        (["station_species"], True),
+        (["species"], True),
+        (["type"], True),
+        (["last_phenophase"], True),
+        (["source"], True),
+        (["deveui"], True),
+        (["source", "other_values"], True),
+        (["other_values"], False),
+        (["reprocess"], True),
+    ],
+)
+def test_should_update__on_update(updated_fields, expected):
+    assert pheno_map._should_update(updated_fields, False, None, None) == expected
 
 
 def test_delete(mapdata):


### PR DESCRIPTION
If new Individuals or Stations are created only trigger map changes if they would be shown on the map. (contain a station species or last_phenophase)

relates to #245 