### PR TITLE
[Automated] Update GitHub Action Versions

### DIFF
--- a/.github/workflows/copyback.yml
+++ b/.github/workflows/copyback.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.1.7
       - name: Setup Node ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4.0.3
+        uses: actions/setup-node@v4.0.4
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: install firebase-tools
@@ -118,6 +118,6 @@ jobs:
     needs: install-functions
     steps:
       - name: call restore function
-        uses: fjogeleit/http-request-action@v1.16.1
+        uses: fjogeleit/http-request-action@v1.16.2
         with:
           url: "https://europe-west1-phaenonet-test.cloudfunctions.net/e2e_restore_users"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,14 +42,14 @@ jobs:
       #     fail_on_error: True
       #   if: always()
       - name: Check black
-        uses: reviewdog/action-black@v3.20.0
+        uses: reviewdog/action-black@v3.21.0
         with:
           reporter: github-check
           verbose: True
           fail_on_error: True
         if: always()
       - name: Check markdownlint
-        uses: reviewdog/action-markdownlint@v0.24.0
+        uses: reviewdog/action-markdownlint@v0.25.0
         with:
           reporter: github-check
           fail_on_error: True

--- a/.github/workflows/version-updater.yml
+++ b/.github/workflows/version-updater.yml
@@ -41,7 +41,7 @@ jobs:
           git diff --exit-code || echo "changes=true" >> $GITHUB_OUTPUT
       - name: Create Pull Request
         if: ${{ steps.git-check.outputs.changes == 'true' }}
-        uses: peter-evans/create-pull-request@v7.0.1
+        uses: peter-evans/create-pull-request@v7.0.5
         with:
           # required to trigger test workflow
           token: ${{ secrets.WORKFLOW_ACCESS_TOKEN }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[reviewdog/action-black](https://github.com/reviewdog/action-black)** published a new release **[v3.21.0](https://github.com/reviewdog/action-black/releases/tag/v3.21.0)** on 2024-09-16T03:33:20Z
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v4.0.4](https://github.com/actions/setup-node/releases/tag/v4.0.4)** on 2024-09-19T14:07:35Z
* **[reviewdog/action-markdownlint](https://github.com/reviewdog/action-markdownlint)** published a new release **[v0.25.0](https://github.com/reviewdog/action-markdownlint/releases/tag/v0.25.0)** on 2024-09-16T03:35:28Z
* **[fjogeleit/http-request-action](https://github.com/fjogeleit/http-request-action)** published a new release **[v1.16.2](https://github.com/fjogeleit/http-request-action/releases/tag/v1.16.2)** on 2024-09-10T13:18:16Z
* **[peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request)** published a new release **[v7.0.5](https://github.com/peter-evans/create-pull-request/releases/tag/v7.0.5)** on 2024-09-18T17:41:45Z
