### PR TITLE
[Automated] Update GitHub Action Versions

### DIFF
--- a/.github/workflows/copyback.yml
+++ b/.github/workflows/copyback.yml
@@ -19,7 +19,7 @@ jobs:
       fs-functions: ${{ steps.fs-functions.outputs.functions }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v4.2.0
       - id: auth
         name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2.1.5
@@ -45,7 +45,7 @@ jobs:
         function: ${{ fromJson(needs.fs-function-matrix.outputs.fs-functions) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v4.2.0
       - id: auth
         name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2.1.5
@@ -64,9 +64,9 @@ jobs:
     environment: phaenonet-test
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v4.2.0
       - name: Setup Node ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4.0.3
+        uses: actions/setup-node@v4.0.4
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: install firebase-tools
@@ -86,7 +86,7 @@ jobs:
     environment: phaenonet-test
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v4.2.0
       - id: auth
         name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2.1.5
@@ -108,7 +108,7 @@ jobs:
       actions: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v4.2.0
       - name: trigger function installation
         run: gh workflow run -f function=all "deploy cloud functions"
         env:
@@ -118,6 +118,6 @@ jobs:
     needs: install-functions
     steps:
       - name: call restore function
-        uses: fjogeleit/http-request-action@v1.16.1
+        uses: fjogeleit/http-request-action@v1.16.2
         with:
           url: "https://europe-west1-phaenonet-test.cloudfunctions.net/e2e_restore_users"

--- a/.github/workflows/deploy-function.yml
+++ b/.github/workflows/deploy-function.yml
@@ -144,7 +144,7 @@ jobs:
       VERSION: "${{ matrix.name }}@${{ github.event.inputs.tag && github.event.inputs.tag || github.sha }}"
     environment: ${{ github.event.inputs.project }}
     steps:
-      - uses: actions/checkout@v4.1.7
+      - uses: actions/checkout@v4.2.0
       - name: Work around https://github.com/actions/checkout/issues/766
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - id: auth

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
       contents: read # checkout
       pull-requests: write # reviewdog
     steps:
-      - uses: actions/checkout@v4.1.7
+      - uses: actions/checkout@v4.2.0
       - name: Install dependencies
         run: pip3 install pipenv
       - name: Sync dev dependencies
@@ -42,14 +42,14 @@ jobs:
       #     fail_on_error: True
       #   if: always()
       - name: Check black
-        uses: reviewdog/action-black@v3.20.0
+        uses: reviewdog/action-black@v3.21.0
         with:
           reporter: github-check
           verbose: True
           fail_on_error: True
         if: always()
       - name: Check markdownlint
-        uses: reviewdog/action-markdownlint@v0.24.0
+        uses: reviewdog/action-markdownlint@v0.25.0
         with:
           reporter: github-check
           fail_on_error: True

--- a/.github/workflows/version-updater.yml
+++ b/.github/workflows/version-updater.yml
@@ -9,7 +9,7 @@ jobs:
   actions-update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.7
+      - uses: actions/checkout@v4.2.0
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_ACCESS_TOKEN }}
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     container: globeswiss/cloud-sdk:py3.12.5-488.0.0
     steps:
-      - uses: actions/checkout@v4.1.7
+      - uses: actions/checkout@v4.2.0
       - name: Work around https://github.com/actions/checkout/issues/766
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: install dependencies
@@ -41,7 +41,7 @@ jobs:
           git diff --exit-code || echo "changes=true" >> $GITHUB_OUTPUT
       - name: Create Pull Request
         if: ${{ steps.git-check.outputs.changes == 'true' }}
-        uses: peter-evans/create-pull-request@v7.0.1
+        uses: peter-evans/create-pull-request@v7.0.5
         with:
           # required to trigger test workflow
           token: ${{ secrets.WORKFLOW_ACCESS_TOKEN }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[reviewdog/action-black](https://github.com/reviewdog/action-black)** published a new release **[v3.21.0](https://github.com/reviewdog/action-black/releases/tag/v3.21.0)** on 2024-09-16T03:33:20Z
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v4.0.4](https://github.com/actions/setup-node/releases/tag/v4.0.4)** on 2024-09-19T14:07:35Z
* **[fjogeleit/http-request-action](https://github.com/fjogeleit/http-request-action)** published a new release **[v1.16.2](https://github.com/fjogeleit/http-request-action/releases/tag/v1.16.2)** on 2024-09-10T13:18:16Z
* **[reviewdog/action-markdownlint](https://github.com/reviewdog/action-markdownlint)** published a new release **[v0.25.0](https://github.com/reviewdog/action-markdownlint/releases/tag/v0.25.0)** on 2024-09-16T03:35:28Z
* **[peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request)** published a new release **[v7.0.5](https://github.com/peter-evans/create-pull-request/releases/tag/v7.0.5)** on 2024-09-18T17:41:45Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.2.0](https://github.com/actions/checkout/releases/tag/v4.2.0)** on 2024-09-25T17:52:55Z
