### PR TITLE
[Automated] Update GitHub Action Versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,14 +42,14 @@ jobs:
       #     fail_on_error: True
       #   if: always()
       - name: Check black
-        uses: reviewdog/action-black@v3.21.0
+        uses: reviewdog/action-black@v3.22.2
         with:
           reporter: github-check
           verbose: True
           fail_on_error: True
         if: always()
       - name: Check markdownlint
-        uses: reviewdog/action-markdownlint@v0.25.0
+        uses: reviewdog/action-markdownlint@v0.26.0
         with:
           reporter: github-check
           fail_on_error: True
@@ -58,7 +58,7 @@ jobs:
         run: pipenv run python -m pytest --cov-report xml --cov=main --cov=phenoback --cov-branch
         if: always()
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5.0.7
+        uses: codecov/codecov-action@v5.1.1
         with:
           use_oidc: true
           files: ./coverage.xml


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[reviewdog/action-markdownlint](https://github.com/reviewdog/action-markdownlint)** published a new release **[v0.26.0](https://github.com/reviewdog/action-markdownlint/releases/tag/v0.26.0)** on 2024-12-03T00:24:37Z
* **[reviewdog/action-black](https://github.com/reviewdog/action-black)** published a new release **[v3.22.2](https://github.com/reviewdog/action-black/releases/tag/v3.22.2)** on 2024-12-04T23:43:50Z
* **[codecov/codecov-action](https://github.com/codecov/codecov-action)** published a new release **[v5.1.1](https://github.com/codecov/codecov-action/releases/tag/v5.1.1)** on 2024-12-05T21:11:43Z
