### PR TITLE
[Automated] Update GitHub Action Versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
       - name: Install uv
-        uses: astral-sh/setup-uv@v5.2.2
+        uses: astral-sh/setup-uv@v5.3.1
       - name: Sync dev dependencies
         run: uv sync
       - name: Check requirements file
@@ -51,7 +51,7 @@ jobs:
         run: uv run python -m pytest --cov-report xml --cov=main --cov=phenoback --cov-branch
         if: always()
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5.3.1
+        uses: codecov/codecov-action@v5.4.0
         with:
           use_oidc: true
           files: ./coverage.xml

--- a/.github/workflows/version-updater.yml
+++ b/.github/workflows/version-updater.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Work around https://github.com/actions/checkout/issues/766
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Install uv
-        uses: astral-sh/setup-uv@v5.2.2
+        uses: astral-sh/setup-uv@v5.3.1
       - name: Update environment
         run: uv lock --upgrade
       - name: Update requirements.txt
@@ -41,7 +41,7 @@ jobs:
           git diff --exit-code || echo "changes=true" >> $GITHUB_OUTPUT
       - name: Create Pull Request
         if: ${{ steps.git-check.outputs.changes == 'true' }}
-        uses: peter-evans/create-pull-request@v7.0.6
+        uses: peter-evans/create-pull-request@v7.0.8
         with:
           # required to trigger test workflow
           token: ${{ secrets.WORKFLOW_ACCESS_TOKEN }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request)** published a new release **[v7.0.8](https://github.com/peter-evans/create-pull-request/releases/tag/v7.0.8)** on 2025-03-04T10:35:28Z
* **[codecov/codecov-action](https://github.com/codecov/codecov-action)** published a new release **[v5.4.0](https://github.com/codecov/codecov-action/releases/tag/v5.4.0)** on 2025-02-26T23:41:16Z
* **[astral-sh/setup-uv](https://github.com/astral-sh/setup-uv)** published a new release **[v5.3.1](https://github.com/astral-sh/setup-uv/releases/tag/v5.3.1)** on 2025-03-01T18:13:09Z
