### PR TITLE
[Automated] Update GitHub Action Versions

### DIFF
--- a/.github/workflows/copyback.yml
+++ b/.github/workflows/copyback.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.2.2
       - name: Setup Node ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4.2.0
+        uses: actions/setup-node@v4.3.0
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: install firebase-tools

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,14 +35,14 @@ jobs:
         run: uv run pylint --reports=y phenoback test main.py
         if: always()
       - name: Check black
-        uses: reviewdog/action-black@v3.22.2
+        uses: reviewdog/action-black@v3.22.4
         with:
           reporter: github-check
           verbose: True
           fail_on_error: True
         if: always()
       - name: Check markdownlint
-        uses: reviewdog/action-markdownlint@v0.26.0
+        uses: reviewdog/action-markdownlint@v0.26.2
         with:
           reporter: github-check
           fail_on_error: True


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v4.3.0](https://github.com/actions/setup-node/releases/tag/v4.3.0)** on 2025-03-17T02:44:28Z
* **[reviewdog/action-markdownlint](https://github.com/reviewdog/action-markdownlint)** published a new release **[v0.26.2](https://github.com/reviewdog/action-markdownlint/releases/tag/v0.26.2)** on 2025-03-18T07:08:40Z
* **[reviewdog/action-black](https://github.com/reviewdog/action-black)** published a new release **[v3.22.4](https://github.com/reviewdog/action-black/releases/tag/v3.22.4)** on 2025-03-18T07:09:32Z
