### PR TITLE
[Automated] Update GitHub Action Versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
         run: uv run python -m pytest --cov-report xml --cov=main --cov=phenoback --cov-branch
         if: always()
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5.4.2
+        uses: codecov/codecov-action@v5.4.3
         with:
           use_oidc: true
           files: ./coverage.xml


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[codecov/codecov-action](https://github.com/codecov/codecov-action)** published a new release **[v5.4.3](https://github.com/codecov/codecov-action/releases/tag/v5.4.3)** on 2025-05-15T20:39:19Z
* **[WyriHaximus/github-action-next-semvers](https://github.com/WyriHaximus/github-action-next-semvers)** published a new release **[v1.2.1](https://github.com/WyriHaximus/github-action-next-semvers/releases/tag/v1.2.1)** on 2022-12-19T13:18:37Z
* **[WyriHaximus/github-action-get-previous-tag](https://github.com/WyriHaximus/github-action-get-previous-tag)** published a new release **[v1.4.0](https://github.com/WyriHaximus/github-action-get-previous-tag/releases/tag/v1.4.0)** on 2024-01-28T15:48:12Z
