### PR TITLE
[Automated] Update GitHub Action Versions

### DIFF
--- a/.github/workflows/deploy-function.yml
+++ b/.github/workflows/deploy-function.yml
@@ -82,12 +82,12 @@ jobs:
           fetch-depth: 0
       - name: 'Get previous tag'
         id: previoustag
-        uses: "WyriHaximus/github-action-get-previous-tag@v1"
+        uses: "WyriHaximus/github-action-get-previous-tag@v1.4.0"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - name: 'Get next versions'
         id: semvers
-        uses: "WyriHaximus/github-action-next-semvers@v1"
+        uses: "WyriHaximus/github-action-next-semvers@v1.2.1"
         with:
           version: ${{ steps.previoustag.outputs.tag }}
       - name: New tag

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
       - name: Install uv
-        uses: astral-sh/setup-uv@v6.1.0
+        uses: astral-sh/setup-uv@v6.3.0
       - name: Sync dev dependencies
         run: uv sync
       - name: Check requirements file

--- a/.github/workflows/version-updater.yml
+++ b/.github/workflows/version-updater.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Work around https://github.com/actions/checkout/issues/766
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Install uv
-        uses: astral-sh/setup-uv@v6.1.0
+        uses: astral-sh/setup-uv@v6.3.0
       - name: Update environment
         run: uv lock --upgrade
       - name: Update requirements.txt


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[WyriHaximus/github-action-next-semvers](https://github.com/WyriHaximus/github-action-next-semvers)** published a new release **[v1.2.1](https://github.com/WyriHaximus/github-action-next-semvers/releases/tag/v1.2.1)** on 2022-12-19T13:18:37Z
* **[WyriHaximus/github-action-get-previous-tag](https://github.com/WyriHaximus/github-action-get-previous-tag)** published a new release **[v1.4.0](https://github.com/WyriHaximus/github-action-get-previous-tag/releases/tag/v1.4.0)** on 2024-01-28T15:48:12Z
* **[astral-sh/setup-uv](https://github.com/astral-sh/setup-uv)** published a new release **[v6.3.0](https://github.com/astral-sh/setup-uv/releases/tag/v6.3.0)** on 2025-06-19T19:24:30Z
