### PR TITLE
[Automated] Update GitHub Action Versions

### DIFF
--- a/.github/workflows/copyback.yml
+++ b/.github/workflows/copyback.yml
@@ -19,7 +19,7 @@ jobs:
       fs-functions: ${{ steps.fs-functions.outputs.functions }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v5.0.0
       - id: auth
         name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2.1.12
@@ -27,7 +27,7 @@ jobs:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2.1.5
+        uses: google-github-actions/setup-gcloud@v2.2.0
         with:
           project_id: phaenonet-test
       - id: fs-functions
@@ -45,7 +45,7 @@ jobs:
         function: ${{ fromJson(needs.fs-function-matrix.outputs.fs-functions) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v5.0.0
       - id: auth
         name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2.1.12
@@ -53,7 +53,7 @@ jobs:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2.1.5
+        uses: google-github-actions/setup-gcloud@v2.2.0
         with:
           project_id: phaenonet-test
       - name: Delete Function ${{ matrix.function.name }}
@@ -63,7 +63,7 @@ jobs:
     environment: phaenonet-test
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v5.0.0
       - name: Remove Firebase Extensions
         uses: ./.github/actions/remove-extensions
         with:
@@ -77,7 +77,7 @@ jobs:
     environment: phaenonet-test
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v5.0.0
       - name: Setup Node ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v4.4.0
         with:
@@ -99,7 +99,7 @@ jobs:
     environment: phaenonet-test
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v5.0.0
       - id: auth
         name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2.1.12
@@ -107,7 +107,7 @@ jobs:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_BACKUP_ACCOUNT }}
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2.1.5
+        uses: google-github-actions/setup-gcloud@v2.2.0
         with:
           project_id: phaenonet-test
       - name: Find last backup
@@ -121,7 +121,7 @@ jobs:
       actions: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v5.0.0
       - name: trigger function installation
         run: gh workflow run -f function=all "deploy cloud functions"
         env:
@@ -132,7 +132,7 @@ jobs:
     environment: phaenonet-test
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v5.0.0
       - name: Deploy Firebase Extensions
         uses: ./.github/actions/deploy-extensions
         with:

--- a/.github/workflows/deploy-function.yml
+++ b/.github/workflows/deploy-function.yml
@@ -77,7 +77,7 @@ jobs:
     outputs:
       tag: ${{ steps.new-tag.outputs.tag }}
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@v5.0.0
         with:
           fetch-depth: 0
       - name: 'Get previous tag'
@@ -175,7 +175,7 @@ jobs:
       VERSION: "${{ matrix.name }}@${{ github.event.inputs.tag != 'none' && needs.next-versions.outputs.tag || github.sha }}"
     environment: ${{ github.event.inputs.project }}
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@v5.0.0
       - name: Work around https://github.com/actions/checkout/issues/766
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - id: auth
@@ -185,7 +185,7 @@ jobs:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2.1.5
+        uses: google-github-actions/setup-gcloud@v2.2.0
         with:
           project_id: ${{ env.PROJECT }}
       - name: set release version

--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -35,7 +35,7 @@ jobs:
     environment: ${{ github.event.inputs.project }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v5.0.0
       - name: Remove Firebase Extensions
         uses: ./.github/actions/remove-extensions
         with:
@@ -50,7 +50,7 @@ jobs:
     environment: ${{ github.event.inputs.project }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v5.0.0
       - name: Deploy Firebase Extensions
         uses: ./.github/actions/deploy-extensions
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,9 +19,9 @@ jobs:
       contents: read # checkout
       pull-requests: write # reviewdog
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@v5.0.0
       - name: Install uv
-        uses: astral-sh/setup-uv@v6.4.3
+        uses: astral-sh/setup-uv@v6.5.0
       - name: Sync dev dependencies
         run: uv sync
       - name: Check requirements file

--- a/.github/workflows/version-updater.yml
+++ b/.github/workflows/version-updater.yml
@@ -9,7 +9,7 @@ jobs:
   actions-update:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@v5.0.0
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_ACCESS_TOKEN }}
@@ -27,11 +27,11 @@ jobs:
     runs-on: ubuntu-22.04
     container: globeswiss/cloud-sdk:py3.12.10-524.0.0
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@v5.0.0
       - name: Work around https://github.com/actions/checkout/issues/766
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Install uv
-        uses: astral-sh/setup-uv@v6.4.3
+        uses: astral-sh/setup-uv@v6.5.0
       - name: Update environment
         run: uv lock --upgrade
       - name: Update requirements.txt


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[google-github-actions/setup-gcloud](https://github.com/google-github-actions/setup-gcloud)** published a new release **[v2.2.0](https://github.com/google-github-actions/setup-gcloud/releases/tag/v2.2.0)** on 2025-08-08T20:42:24Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v5.0.0](https://github.com/actions/checkout/releases/tag/v5.0.0)** on 2025-08-11T12:39:13Z
* **[astral-sh/setup-uv](https://github.com/astral-sh/setup-uv)** published a new release **[v6.5.0](https://github.com/astral-sh/setup-uv/releases/tag/v6.5.0)** on 2025-08-12T20:52:48Z
