### PR TITLE
Handle non-existent invite documents gracefully

### DIFF
--- a/phenoback/functions/iot/app.py
+++ b/phenoback/functions/iot/app.py
@@ -25,7 +25,7 @@ def main_individual_updated(data, context):
         if g.get_field(data, "deveui", expected=False):
             individual = g.get_field(data, "individual")
             deveui = g.get_field(data, "deveui")
-            sensor_set(individual_id, individual, deveui)  # type: ignore
+            sensor_set(individual_id, str(individual), str(deveui))
         else:
             remove_sensor(individual_id)
 

--- a/phenoback/functions/iot/dragino.py
+++ b/phenoback/functions/iot/dragino.py
@@ -61,7 +61,7 @@ def set_uplink_frequency(deveui: str, interval: int, at: datetime | None = None)
             "Payload": f"{16777216 + interval:{0}8x}",
             "FPort": 1,
         },
-        at=at,  # type: ignore
+        at=at,
     )
 
 

--- a/test/emulator.py
+++ b/test/emulator.py
@@ -25,7 +25,7 @@ def check():
 def start(xprocess, name):
     class EmulatorClass(ProcessStarter):
         @property
-        def args(self):  # type: ignore
+        def args(self):  # type: ignore  # xprocess base abstract implementation returns void and does not define no return type
             return [
                 _get_gcloud_cmd(),
                 "beta",
@@ -39,7 +39,7 @@ def start(xprocess, name):
             ]
 
         @property
-        def pattern(self):  # type: ignore
+        def pattern(self):  # type: ignore  # xprocess base returns None and no type is defined
             return re.compile(".*is now running.*")
 
     logfile = xprocess.ensure(name, EmulatorClass)


### PR DESCRIPTION
relates to https://github.com/globe-swiss/phaenonet-client/issues/146

Invite lookups are not removed when deleting the invites. Registrations that happen after the invite was deleted will be logged as a warning.