### PR TITLE
[Automated] Update GitHub Action Versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5.0.0
       - name: Install uv
-        uses: astral-sh/setup-uv@v6.5.0
+        uses: astral-sh/setup-uv@v6.6.0
       - name: Sync dev dependencies
         run: uv sync
       - name: Check requirements file
@@ -51,7 +51,7 @@ jobs:
         run: uv run python -m pytest --cov-report xml --cov=main --cov=phenoback --cov-branch
         if: always()
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5.4.3
+        uses: codecov/codecov-action@v5.5.0
         with:
           use_oidc: true
           files: ./coverage.xml

--- a/.github/workflows/version-updater.yml
+++ b/.github/workflows/version-updater.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Work around https://github.com/actions/checkout/issues/766
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Install uv
-        uses: astral-sh/setup-uv@v6.5.0
+        uses: astral-sh/setup-uv@v6.6.0
       - name: Update environment
         run: uv lock --upgrade
       - name: Update requirements.txt


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[codecov/codecov-action](https://github.com/codecov/codecov-action)** published a new release **[v5.5.0](https://github.com/codecov/codecov-action/releases/tag/v5.5.0)** on 2025-08-20T14:04:55Z
* **[astral-sh/setup-uv](https://github.com/astral-sh/setup-uv)** published a new release **[v6.6.0](https://github.com/astral-sh/setup-uv/releases/tag/v6.6.0)** on 2025-08-21T09:24:01Z
