### PR TITLE
[Automated] Update GitHub Action Versions

### DIFF
--- a/.github/workflows/copyback.yml
+++ b/.github/workflows/copyback.yml
@@ -147,7 +147,7 @@ jobs:
       - deploy-extensions
     steps:
       - name: call restore function
-        uses: fjogeleit/http-request-action@v1.16.4
+        uses: fjogeleit/http-request-action@v1.16.5
         with:
           url: "https://europe-west1-phaenonet-test.cloudfunctions.net/e2e_restore_data"
           timeout: 30000

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5.0.0
       - name: Install uv
-        uses: astral-sh/setup-uv@v6.6.1
+        uses: astral-sh/setup-uv@v7.0.0
       - name: Sync dev dependencies
         run: uv sync
       - name: Check requirements file

--- a/.github/workflows/version-updater.yml
+++ b/.github/workflows/version-updater.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Work around https://github.com/actions/checkout/issues/766
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Install uv
-        uses: astral-sh/setup-uv@v6.6.1
+        uses: astral-sh/setup-uv@v7.0.0
       - name: Update environment
         run: uv lock --upgrade
       - name: Update requirements.txt


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[astral-sh/setup-uv](https://github.com/astral-sh/setup-uv)** published a new release **[v7.0.0](https://github.com/astral-sh/setup-uv/releases/tag/v7.0.0)** on 2025-10-07T19:45:32Z
* **[fjogeleit/http-request-action](https://github.com/fjogeleit/http-request-action)** published a new release **[v1.16.5](https://github.com/fjogeleit/http-request-action/releases/tag/v1.16.5)** on 2025-09-16T06:33:46Z
