### PR TITLE
fix statistics after import

### DIFF
--- a/phenoback/functions/rollover.py
+++ b/phenoback/functions/rollover.py
@@ -87,8 +87,10 @@ def rollover():
         "Cleared %i sensors from individuals for %i", cleared_sensors, source_phenoyear
     )
 
-    log.info("Process year aggregate statistics for %i", target_phenoyear)
-    weekly.process_1y_aggregate_statistics(target_phenoyear)
+    log.info("Process year aggregate statistics for %i", source_phenoyear)
+    weekly.process_1y_aggregate_statistics(source_phenoyear)
+    log.info("Process 5/30y aggregate statistics for %i", target_phenoyear)
+    weekly.process_5y_30y_aggregate_statistics(target_phenoyear)
 
     log.info(
         "Setting current phenoyear from %i to %i", source_phenoyear, target_phenoyear

--- a/phenoback/functions/wld_import.py
+++ b/phenoback/functions/wld_import.py
@@ -8,6 +8,7 @@ from zipfile import ZipFile
 
 from google.cloud.storage import Blob
 
+from phenoback.functions.statistics import weekly
 from phenoback.utils import data as d
 from phenoback.utils import firestore as f
 from phenoback.utils import storage as s
@@ -55,8 +56,17 @@ def main(data, context):  # pylint: disable=unused-argument
     """
     pathfile = data["name"]
     if pathfile.startswith("private/wld_import/"):
+        # default to previous year if not specified
+        year = d.get_phenoyear() - 1
         log.info("Import wld data for %s", pathfile)
-        import_data(pathfile)
+        import_data(pathfile, year)
+
+
+def update_statistics(year: int) -> None:
+    log.info("Process year aggregate statistics for %i", year)
+    weekly.process_1y_aggregate_statistics(year)
+    log.info("Process 5/30y aggregate statistics for %i", year)
+    weekly.process_5y_30y_aggregate_statistics(year)
 
 
 def members_by_basename(z: ZipFile) -> dict[str, list[str]]:
@@ -186,7 +196,7 @@ def check_data_integrity():
         raise ValueError("Data integrity check failed")
 
 
-def import_data(pathfile: str, bucket=None, year: int | None = None):
+def import_data(pathfile: str, year: int, bucket=None):
     """
     Main import function that processes WLD data from a ZIP file.
 
@@ -195,9 +205,6 @@ def import_data(pathfile: str, bucket=None, year: int | None = None):
     :param year: Year to import data for (defaults to previous phenological year)
     """
     global loaded_data  # pylint: disable=global-statement
-    # default to previous year if not specified
-    if year is None:
-        year = d.get_phenoyear() - 1
 
     log.info("importing year %i", year)
     blob = s.get_blob(bucket, pathfile)

--- a/test/functions/test_wld_import.py
+++ b/test/functions/test_wld_import.py
@@ -63,8 +63,13 @@ def test_main(mocker, context, pathfile, called):
     the function invocation to specific folders.
     """
     mock = mocker.patch("phenoback.functions.wld_import.import_data")
+    current_phenoyear = 2002
+    d.update_phenoyear(current_phenoyear)
     wld_import.main({"name": pathfile}, context)
-    assert mock.called == called
+    if called:
+        mock.assert_called_once_with(pathfile, current_phenoyear - 1)
+    else:
+        assert not mock.called
 
 
 def test_check_zip_archive(zippath):
@@ -194,8 +199,7 @@ def test_check_data_integrity__duplicate_tree_error(data_loaded, caperrors):
 
 def test_import_data(mocker, input_blob):
     mocker.patch("phenoback.utils.storage.get_blob", return_value=input_blob)
-    d.update_phenoyear(2002)  # assume test data from 2001
-    wld_import.import_data("mocked")
+    wld_import.import_data("mocked", 2001)  # assume test data from 2001
     assert len(f.get_collection_documents("users")) == 4
     assert len(f.get_collection_documents("public_users")) == 4
     assert len(f.get_collection_documents("individuals")) == 2
@@ -204,8 +208,7 @@ def test_import_data(mocker, input_blob):
 
 def test_import_data__no_data(mocker, caperrors, input_blob):
     mocker.patch("phenoback.utils.storage.get_blob", return_value=input_blob)
-    d.update_phenoyear(2021)  # assume test data from 2020
-    wld_import.import_data("mocked")
+    wld_import.import_data("mocked", 2020)  # assume test data from 2020
     assert len(f.get_collection_documents("users")) == 4
     assert len(f.get_collection_documents("public_users")) == 4
     assert len(f.get_collection_documents("individuals")) == 0


### PR DESCRIPTION
* fix statistic calculation after import of wld data. Trigger recalculation.
* fix statistic calculation on rollover. Calculate 5/30y averages for upcoming year